### PR TITLE
update whitenoise configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=1.8.0,<2.0.0
 chatterbot>=0.7.6,<0.7.7
 gunicorn
-whitenoise
+whitenoise==5.3.0


### PR DESCRIPTION
Following instructions on the README leads to the following error:

```
Your WhiteNoise configuration is incompatible with WhiteNoise v4.0
This can be fixed by following the upgrade instructions at:
https://whitenoise.evans.io/en/stable/changelog.html#v4-0
```

I've followed the instructions in the error message to update the settings, and froze the whitenoise version